### PR TITLE
Fixed wrong equation

### DIFF
--- a/filebytes/mach_o.py
+++ b/filebytes/mach_o.py
@@ -532,7 +532,7 @@ class MachO(Binary):
             else:
                 offset += sizeof(self._classes.Section)
 
-            if self.machHeader.header.filetype != MH.DSYM or segment.segname == "__DWARF":
+            if self.machHeader.header.filetype != MH.DSYM or segment.segname == b"__DWARF":
                 raw = (c_ubyte * sec.size).from_buffer(data, sec.offset)
                 bytes = bytearray(raw)
             else:


### PR DESCRIPTION
`segment.segname` is a `bytes`, not a `str`.
The wrong condition resulted in sections with empty an `bytes` attribute