### PR TITLE
ARM64E is now supported by Xcode alongside ARM64

### DIFF
--- a/filebytes/mach_o.py
+++ b/filebytes/mach_o.py
@@ -92,6 +92,11 @@ class CpuSubTypeARM(Enum):
     V7M = 15
     V7EM = 16
 
+class CPUSubTypeARM64(Enum):
+    ALL = 0
+    V8 = 1
+    E = 2    
+
 class SubTypeFlags(Enum):
     MASK = 0xff000000
     LIB64 = 0x80000000

--- a/filebytes/mach_o.py
+++ b/filebytes/mach_o.py
@@ -92,7 +92,7 @@ class CpuSubTypeARM(Enum):
     V7M = 15
     V7EM = 16
 
-class CPUSubTypeARM64(Enum):
+class CpuSubTypeARM64(Enum):
     ALL = 0
     V8 = 1
     E = 2    


### PR DESCRIPTION
An enum with CPU subtype values would be in order.