### PR TITLE
Dummy sections take 2

### DIFF
--- a/filebytes/mach_o.py
+++ b/filebytes/mach_o.py
@@ -549,7 +549,7 @@ class MachO(Binary):
             else:
                 offset += sizeof(self._classes.Section)
 
-            if self.machHeader.header.filetype != MH.DSYM or segment.segname == b"__DWARF":
+            if sec.offset > 0:
                 raw = (c_ubyte * sec.size).from_buffer(data, sec.offset)
                 bytes = bytearray(raw)
             else:


### PR DESCRIPTION
This amends my old PR, #24. Here is the background.

When you build an iOS app for distribution, it generates debug symbols in a separate bundle ("the dSYM bundle"). The bundle contains a MachO binary that lists all the normal program sections - `__text`, `__data` - but doesn't contain them physically. Parsing those dSYM binaries with `filebytes` is a part of my use case. I was assuming, for a while, that the only real sections in those are the `__debug_xxx` ones (i. e. DWARF).

Now, in a recent Xcode build, I'm looking at a dSYM bundle where there are some real sections outside of DWARF - specifically, `__eh_frame` and `__unwind__info`, in the `__TEXT` segment. Looking at those is relevant to my use case, also.

Taking a closer look at the MachO headers of a dSYM bundle, I've noticed that **all dummied out sections have their `offset` field set to zero**. I tried finding a reference to this behavior in ABI documents, but could not. Other section header fields look as if the section was real. So rather than trying to check for all section names that *might* be present in a dSYM in `__parseSections`, I've changed the check to just that - nonzero offset means the section is present.

This might lead to higher memory consumption when loading dSYM bundles (e. g. there are some nondummy vendor sections in the __DWARF segment). But at least no sections will be left behind (unless another ABI quirk surfaces).